### PR TITLE
Member 닉네임 수정 & 로그아웃 기능 구현

### DIFF
--- a/src/main/java/efub/SweetMeback/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/SweetMeback/domain/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package efub.SweetMeback.domain.member.controller;
 
 import efub.SweetMeback.domain.member.dto.MemberResponseDto;
+import efub.SweetMeback.domain.member.dto.MemberUpdateRequestDto;
 import efub.SweetMeback.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @Slf4j
 @RestController
@@ -17,6 +20,13 @@ public class MemberController {
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
     public MemberResponseDto getMember(){
+        return memberService.getMember();
+    }
+
+    @PatchMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    public MemberResponseDto updateMemberNickname(@RequestBody @Valid final MemberUpdateRequestDto requestDto){
+        memberService.updateMemberNickname(requestDto);
         return memberService.getMember();
     }
 }

--- a/src/main/java/efub/SweetMeback/domain/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/efub/SweetMeback/domain/member/dto/MemberUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package efub.SweetMeback.domain.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberUpdateRequestDto {
+    private String nickname;
+}

--- a/src/main/java/efub/SweetMeback/domain/member/entity/Member.java
+++ b/src/main/java/efub/SweetMeback/domain/member/entity/Member.java
@@ -32,4 +32,8 @@ public class Member {
         this.nickname = nickname;
         this.email = email;
     }
+
+    public void updateMemberNickname(String nickname){
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/efub/SweetMeback/domain/member/service/MemberService.java
+++ b/src/main/java/efub/SweetMeback/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package efub.SweetMeback.domain.member.service;
 
 import efub.SweetMeback.domain.member.dto.MemberResponseDto;
+import efub.SweetMeback.domain.member.dto.MemberUpdateRequestDto;
 import efub.SweetMeback.domain.member.entity.Member;
 import efub.SweetMeback.domain.member.repository.MemberRepository;
 import efub.SweetMeback.domain.oauth.service.OAuthService;
@@ -24,9 +25,11 @@ public class MemberService {
         return new MemberResponseDto(nickname, email);
     }
 
-    @Transactional(readOnly = true)
-    public Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(()->new IllegalArgumentException("존재하지 않는 계정입니다."));
+    public void updateMemberNickname(MemberUpdateRequestDto requestDto){
+        Member member = oAuthService.getCurrentMember();
+        member.updateMemberNickname(requestDto.getNickname());
+        memberRepository.save(member);
     }
+
+
 }

--- a/src/main/java/efub/SweetMeback/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/efub/SweetMeback/domain/oauth/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package efub.SweetMeback.domain.oauth.controller;
 
+import efub.SweetMeback.domain.member.entity.Member;
 import efub.SweetMeback.domain.oauth.dto.OAuthRequestDto;
 import efub.SweetMeback.domain.oauth.dto.OAuthResponseDto;
 import efub.SweetMeback.domain.oauth.service.OAuthService;
@@ -7,6 +8,10 @@ import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpSession;
+import java.util.HashMap;
+import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -18,7 +23,30 @@ public class OAuthController {
 
     @ResponseBody
     @PostMapping("/login")
-    public OAuthResponseDto login(@RequestBody OAuthRequestDto oAuthRequestDto) {
-        return oAuthService.signIn(oAuthRequestDto.getCode());
+    public OAuthResponseDto login(@RequestBody OAuthRequestDto oAuthRequestDto, HttpSession session) {
+        OAuthResponseDto member = oAuthService.signIn(oAuthRequestDto.getCode());
+
+        if (member.getEmail() != null) {
+            session.setAttribute("userId", member.getEmail());
+            session.setAttribute("access_Token", member.getAccessToken());
+        }
+
+        return member;
+    }
+
+    @PostMapping("/logout")
+    public String logout(HttpSession session) {
+        String access_Token = (String)session.getAttribute("access_Token");
+        System.out.println(access_Token);
+
+        if(access_Token != null && !"".equals(access_Token)){
+            oAuthService.logout(access_Token);
+            session.removeAttribute("access_Token");
+            session.removeAttribute("userId");
+            System.out.println("logout success");
+        }else{
+            System.out.println("access_Token is null");
+        }
+        return "redirect:/";
     }
 }

--- a/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
+++ b/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
@@ -18,6 +18,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.*;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 @Slf4j
@@ -166,24 +167,12 @@ public class OAuthService{
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Authorization", "Bearer " + access_Token);
 
-            int responseCode = conn.getResponseCode();
-            System.out.println("responseCode : " + responseCode);
-
-            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-
-            String result = "";
-            String line = "";
-
-            while ((line = br.readLine()) != null) {
-                result += line;
-            }
-            System.out.println(result);
+            conn.disconnect();
+        } catch (MalformedURLException e){
+            e.printStackTrace();
         } catch (IOException e) {
-            // TODO Auto-generated catch block
             e.printStackTrace();
         }
-
-
     }
 
     public Member getCurrentMember() {


### PR DESCRIPTION
# 구현 기능
- 회원 닉네임 변경
- 로그아웃: 로그인 시 HttpSession에 Access_Token 넣어둔 후, 로그아웃 시 넣어둔 Access_Token 제거

# 구현 상태
- 닉네임 변경
![스크린샷 2023-11-03 195415](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/89291223/e14382a9-8929-4dce-b25d-adbf36e14bef)

- 닉네임 변경 전 DB
![스크린샷 2023-11-03 195354](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/89291223/594bb371-5b93-4c31-8bc1-2507b12c1ec1)

- 닉네임 변경 후 DB
![스크린샷 2023-11-03 195425](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/89291223/caf6977d-510c-40e3-bd8b-9ff6adf6f1c3)


- 로그아웃 
![스크린샷 2023-11-03 195239](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/89291223/70bcfca8-5ae3-4c65-b2bd-e8931bb2d410)
![스크린샷 2023-11-03 195252](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/89291223/1d358f20-b6d0-4ef1-81ff-71b348bb5a8a)

# Resolve
- #3 