### PR TITLE
✨ feat: 메인페이지 필터링 및 정렬 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.11'
 	id 'io.spring.dependency-management' version '1.1.3'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'efub'
@@ -39,4 +46,22 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/efub/SweetMeback/domain/post/controller/PostController.java
+++ b/src/main/java/efub/SweetMeback/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package efub.SweetMeback.domain.post.controller;
 
 import efub.SweetMeback.domain.heart.service.HeartService;
+import efub.SweetMeback.domain.post.dto.PostFilteringRequest;
 import efub.SweetMeback.domain.post.dto.PostRequestDto;
 import efub.SweetMeback.domain.post.dto.PostResponseDto;
 import efub.SweetMeback.domain.post.dto.PostResponseDtoWithHeart;
@@ -56,6 +57,11 @@ public class PostController {
     @GetMapping("/promotion")
     public ResponseEntity<List<PostResponseDtoWithHeart>> findPostsByPromotion() {
         return ResponseEntity.ok(postService.findPostsByPromotion());
+    }
+
+    @GetMapping("/filtering")
+    public ResponseEntity<List<PostResponseDtoWithHeart>> filtering(PostFilteringRequest filteringRequest) {
+        return ResponseEntity.ok(postService.filtering(filteringRequest));
     }
 
     @PostMapping("/{post_id}/hearts")

--- a/src/main/java/efub/SweetMeback/domain/post/dto/PostFilteringRequest.java
+++ b/src/main/java/efub/SweetMeback/domain/post/dto/PostFilteringRequest.java
@@ -1,0 +1,20 @@
+package efub.SweetMeback.domain.post.dto;
+
+import efub.SweetMeback.domain.post.entity.Category;
+import efub.SweetMeback.domain.post.entity.Sort;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Data
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostFilteringRequest {
+
+    private boolean recruitment;
+
+    private Category category;
+
+    private Sort sort;
+}

--- a/src/main/java/efub/SweetMeback/domain/post/entity/Sort.java
+++ b/src/main/java/efub/SweetMeback/domain/post/entity/Sort.java
@@ -1,0 +1,12 @@
+package efub.SweetMeback.domain.post.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Sort {
+    DATE("최신순"),
+    VIEW("조회수순"),
+    HEART("좋아요순");
+
+    private final String detail;
+}

--- a/src/main/java/efub/SweetMeback/domain/post/repository/PostRepository.java
+++ b/src/main/java/efub/SweetMeback/domain/post/repository/PostRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
     @Modifying
     @Query("update Post p set p.view = p.view + 1 where p.id = :id")

--- a/src/main/java/efub/SweetMeback/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/efub/SweetMeback/domain/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,12 @@
+package efub.SweetMeback.domain.post.repository;
+
+import efub.SweetMeback.domain.post.dto.PostFilteringRequest;
+import efub.SweetMeback.domain.post.entity.Post;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+
+    List<Post> filteringAll(PostFilteringRequest filteringRequest);
+
+}

--- a/src/main/java/efub/SweetMeback/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/efub/SweetMeback/domain/post/repository/PostRepositoryCustom.java
@@ -8,5 +8,4 @@ import java.util.List;
 public interface PostRepositoryCustom {
 
     List<Post> filteringAll(PostFilteringRequest filteringRequest);
-
 }

--- a/src/main/java/efub/SweetMeback/domain/post/service/PostRepositoryImpl.java
+++ b/src/main/java/efub/SweetMeback/domain/post/service/PostRepositoryImpl.java
@@ -71,7 +71,4 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         }
         return null;
     }
-
-
-
 }

--- a/src/main/java/efub/SweetMeback/domain/post/service/PostRepositoryImpl.java
+++ b/src/main/java/efub/SweetMeback/domain/post/service/PostRepositoryImpl.java
@@ -1,0 +1,77 @@
+package efub.SweetMeback.domain.post.service;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import efub.SweetMeback.domain.post.dto.PostFilteringRequest;
+import efub.SweetMeback.domain.post.entity.Category;
+import efub.SweetMeback.domain.post.entity.Post;
+import efub.SweetMeback.domain.post.entity.Sort;
+import efub.SweetMeback.domain.post.repository.PostRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static efub.SweetMeback.domain.post.entity.QPost.post;
+
+@Service
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Post> filteringAll(PostFilteringRequest filteringRequest) {
+        List<Post> postList = new ArrayList<>();
+        Sort sort = filteringRequest.getSort();
+
+        OrderSpecifier<LocalDateTime> createdDateSpecifier = post.createdDate.desc();
+        OrderSpecifier<Integer> viewSpecifier = post.view.desc();
+        OrderSpecifier<Long> heartCountSpecifier = post.heartCount.desc();
+
+        if (sort != null) {
+            if (sort.equals(Sort.DATE)) {
+                postList = filteringQuery(filteringRequest).orderBy(createdDateSpecifier).fetch();
+            } else if (sort.equals(Sort.VIEW)) {
+                postList = filteringQuery(filteringRequest).orderBy(viewSpecifier).fetch();
+            } else if (sort.equals(Sort.HEART)) {
+                postList = filteringQuery(filteringRequest).orderBy(heartCountSpecifier).fetch();
+            }
+        } else {
+            postList = filteringQuery(filteringRequest).orderBy(createdDateSpecifier).fetch();
+        }
+
+        return postList;
+    }
+
+    private JPAQuery<Post> filteringQuery(PostFilteringRequest filteringRequest) {
+        return jpaQueryFactory
+                .selectFrom(post)
+                .where(
+                        recruitmentCondition(filteringRequest.isRecruitment()),
+                        categoryCondition(filteringRequest.getCategory())
+                )
+                .groupBy(post);
+    }
+
+    private BooleanExpression recruitmentCondition(Boolean recruitment) {
+        if (recruitment != null) {
+            return post.recruitment.eq(recruitment);
+        }
+        return null;
+    }
+
+    private BooleanExpression categoryCondition(Category category) {
+        if (category != null) {
+            return post.category.eq(category);
+        }
+        return null;
+    }
+
+
+
+}

--- a/src/main/java/efub/SweetMeback/domain/post/service/PostService.java
+++ b/src/main/java/efub/SweetMeback/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package efub.SweetMeback.domain.post.service;
 import efub.SweetMeback.domain.heart.service.HeartService;
 import efub.SweetMeback.domain.member.entity.Member;
 import efub.SweetMeback.domain.oauth.service.OAuthService;
+import efub.SweetMeback.domain.post.dto.PostFilteringRequest;
 import efub.SweetMeback.domain.post.dto.PostRequestDto;
 import efub.SweetMeback.domain.post.dto.PostResponseDtoWithHeart;
 import efub.SweetMeback.domain.post.entity.Post;
@@ -103,6 +104,19 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<PostResponseDtoWithHeart> findPostsByPromotion() {
         List<Post> postList = postRepository.findAllByPromotion(true);
+
+        List<PostResponseDtoWithHeart> responseList = new ArrayList<>();
+        for (Post post : postList) {
+            boolean isHeart = heartService.isHeartByMember(post);
+            responseList.add(new PostResponseDtoWithHeart(post, isHeart));
+        }
+
+        return responseList;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostResponseDtoWithHeart> filtering(PostFilteringRequest filteringRequest) {
+        List<Post> postList = postRepository.filteringAll(filteringRequest);
 
         List<PostResponseDtoWithHeart> responseList = new ArrayList<>();
         for (Post post : postList) {

--- a/src/main/java/efub/SweetMeback/domain/post/service/PostService.java
+++ b/src/main/java/efub/SweetMeback/domain/post/service/PostService.java
@@ -113,6 +113,20 @@ public class PostService {
         }
 
         return responseList;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostResponseDtoWithHeart> filtering(PostFilteringRequest filteringRequest) {
+        List<Post> postList = postRepository.filteringAll(filteringRequest);
+
+        List<PostResponseDtoWithHeart> responseList = new ArrayList<>();
+        for (Post post : postList) {
+            boolean isHeart = heartService.isHeartByMember(post);
+            responseList.add(new PostResponseDtoWithHeart(post, isHeart));
+        }
+
+        return responseList;
+    }
 
     public void removePost(Long postId){
         Member member = oAuthService.getCurrentMember();
@@ -137,18 +151,5 @@ public class PostService {
         postRepository.save(post);
         return post;
 
-    }
-
-    @Transactional(readOnly = true)
-    public List<PostResponseDtoWithHeart> filtering(PostFilteringRequest filteringRequest) {
-        List<Post> postList = postRepository.filteringAll(filteringRequest);
-
-        List<PostResponseDtoWithHeart> responseList = new ArrayList<>();
-        for (Post post : postList) {
-            boolean isHeart = heartService.isHeartByMember(post);
-            responseList.add(new PostResponseDtoWithHeart(post, isHeart));
-        }
-
-        return responseList;
     }
 }

--- a/src/main/java/efub/SweetMeback/global/config/QueryDslConfig.java
+++ b/src/main/java/efub/SweetMeback/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package efub.SweetMeback.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## Details
- 메인페이지 필터링 및 정렬 기능
- 메인페이지에서 카테고리와 모집 여부를 선택해서 검색할 수 있습니다. 동시에 최신순, 조회수순, 좋아요순을 선택하여 모집글을 정렬하는 것도 가능합니다.

## Image
![image](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/97473239/aed7ca69-546b-4b52-81c9-7fc3bf3ea7b0)

## Resolve
- #22 