### PR TITLE
회원가입시 프로필 이미지 저장, 처음가입 구분 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'com.google.code.gson:gson:2.8.7'
+	implementation 'com.google.code.gson:gson:2.8.9'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'

--- a/src/main/java/efub/SweetMeback/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/efub/SweetMeback/domain/member/dto/MemberResponseDto.java
@@ -8,9 +8,11 @@ import lombok.NoArgsConstructor;
 public class MemberResponseDto {
     private String nickname;
     private String email;
+    private String profileImage;
 
-    public MemberResponseDto(String nickname, String email){
+    public MemberResponseDto(String nickname, String email, String profileImage){
         this.nickname = nickname;
         this.email = email;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/efub/SweetMeback/domain/member/entity/Member.java
+++ b/src/main/java/efub/SweetMeback/domain/member/entity/Member.java
@@ -26,11 +26,15 @@ public class Member {
     @Column(nullable = false)
     private String nickname;
 
+    @Column(nullable = false)
+    private String profileImage;
+
     @Builder
-    public Member(String name, String nickname, String email){
+    public Member(String name, String nickname, String email, String profileImage){
         this.name=name;
         this.nickname = nickname;
         this.email = email;
+        this.profileImage = profileImage;
     }
 
     public void updateMemberNickname(String nickname){

--- a/src/main/java/efub/SweetMeback/domain/member/service/MemberService.java
+++ b/src/main/java/efub/SweetMeback/domain/member/service/MemberService.java
@@ -22,7 +22,8 @@ public class MemberService {
         Member member = oAuthService.getCurrentMember();
         String nickname = member.getNickname();
         String email = member.getEmail();
-        return new MemberResponseDto(nickname, email);
+        String profileImage = member.getProfileImage();
+        return new MemberResponseDto(nickname, email, profileImage);
     }
 
     public void updateMemberNickname(MemberUpdateRequestDto requestDto){

--- a/src/main/java/efub/SweetMeback/domain/oauth/dto/OAuthResponseDto.java
+++ b/src/main/java/efub/SweetMeback/domain/oauth/dto/OAuthResponseDto.java
@@ -13,12 +13,14 @@ public class OAuthResponseDto {
     private String email;
     private String accessToken;
     private String refreshToken;
+    private boolean isfirst;
 
     @Builder
-    public OAuthResponseDto(Member member, String accessToken, String refreshToken) {
+    public OAuthResponseDto(Member member, String accessToken, String refreshToken, boolean isfirst) {
         this.nickname = member.getNickname();
         this.email = member.getEmail();
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.isfirst = isfirst;
     }
 }

--- a/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
+++ b/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
@@ -122,9 +122,11 @@ public class OAuthService{
             String name = properties.getAsJsonObject().get("nickname").getAsString();
             String nickname = properties.getAsJsonObject().get("nickname").getAsString();
             String email = kakao_account.getAsJsonObject().get("email").getAsString();
+            String profileImage = properties.getAsJsonObject().get("profile_image").getAsString();
 
             System.out.println("nickname : " + nickname);
             System.out.println("email : " + email);
+            System.out.println("profile_image: "+ profileImage);
 
             member = memberRepository.findByEmail(email);
             if(member != null) {
@@ -135,6 +137,7 @@ public class OAuthService{
                         .name(name)
                         .nickname(nickname)
                         .email(email)
+                        .profileImage(profileImage)
                         .build();
                 memberRepository.save(member);
             }

--- a/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
+++ b/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
@@ -120,11 +120,16 @@ public class OAuthService{
 
             JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
             JsonObject kakao_account = element.getAsJsonObject().get("kakao_account").getAsJsonObject();
+            JsonObject kakao_profile = kakao_account.get("profile").getAsJsonObject();
 
             String name = properties.getAsJsonObject().get("nickname").getAsString();
             String nickname = properties.getAsJsonObject().get("nickname").getAsString();
             String email = kakao_account.getAsJsonObject().get("email").getAsString();
-            String profileImage = properties.getAsJsonObject().get("profile_image").getAsString();
+            String profileImage;
+            if(kakao_profile.getAsJsonObject().get("is_default_image").getAsBoolean())
+                profileImage = "https://drive.google.com/file/d/1Ty3KesiUVDeWs6YPOP-iXA5IG3Z-h6hD/view?usp=drive_link";
+            else
+                profileImage = kakao_profile.getAsJsonObject().get("profile_image_url").getAsString();
 
             System.out.println("nickname : " + nickname);
             System.out.println("email : " + email);

--- a/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
+++ b/src/main/java/efub/SweetMeback/domain/oauth/service/OAuthService.java
@@ -31,6 +31,8 @@ public class OAuthService{
     @Value("${kakao.redirect-url}")
     private String redirectUrl;
 
+    private boolean isFirst;
+
     public final JwtProvider jwtProvider;
 
     public String getKakaoAccessToken (String code) {
@@ -131,6 +133,7 @@ public class OAuthService{
             member = memberRepository.findByEmail(email);
             if(member != null) {
                 log.info("이미 가입한 계정");
+                isFirst=false;
             }
             else{
                 member = Member.builder()
@@ -140,6 +143,7 @@ public class OAuthService{
                         .profileImage(profileImage)
                         .build();
                 memberRepository.save(member);
+                isFirst=true;
             }
 
         } catch (IOException e) {
@@ -159,6 +163,7 @@ public class OAuthService{
                 .member(member)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .isfirst(isFirst)
                 .build();
     }
 


### PR DESCRIPTION
# 구현 기능
- 회원가입시 카카오 프로필 이미지도 함께 저장
- 만약 카카오 프로필 이미지가 기본 이미지라면 사탕사진으로 저장
- 사용자 정보 가져올 때, 프로필 이미지 포함
- 처음 가입하는 사용자와 로그인하는 사용자 구분(가입하는 경우 isfirst=true, 기존 사용자가 로그인하는 경우 is first=false)

# 구현 상태
- 프로필 사진
![스크린샷 2023-11-13 004621](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/89291223/e3aeeb6b-f504-49b3-ba24-6fa564464230)

- 회원가입 유무 구분
![스크린샷 2023-11-13 004554](https://github.com/SweetMe-Sweetie/SweetMe-Back/assets/89291223/0975c6b0-5ba1-4990-b9ad-d6985d329340)
